### PR TITLE
add responsiveness, fixes a few bugs

### DIFF
--- a/ckanext/surrey/fanstatic_library/css/surrey.css
+++ b/ckanext/surrey/fanstatic_library/css/surrey.css
@@ -21,11 +21,23 @@ font-weight: normal;
 width: 450px;
 float: right;
 margin-right: 15px;
-  height: 130px;
-  line-height: 130px;
+height: 130px;
+line-height: 130px;
 display: block;
 }
+@media only screen and (max-width: 551px){
+  .intro-text header {
+    display: none;
 
+  }
+}
+@media only screen and (max-width: 991px){
+  .intro-text header{
+    float:none;
+    width:100%;
+    height:auto;
+  }
+}
 .intro-text header a {
 text-decoration: underline;
 color: #fff;
@@ -39,11 +51,28 @@ color: #fff;
 .intro-text header p {
 display: inline-block;
  vertical-align: middle;
-  line-height: 140%;      
+  line-height: 140%;
 }
 
 .intro-image img {
    margin-top: 20px;
+}
+
+@media only screen and (max-width:991px){
+  .intro-image img{
+    margin-top:0px;
+    padding-top:0px;
+  }
+}
+
+@media only screen and (max-width:551px){
+  .intro-image img{
+    width:80%;
+    margin-top:20px;
+    margin-left:auto;
+    margin-right:auto;
+
+  }
 }
 .masonry .media-image, .masonry .media-heading {
 display: block;
@@ -192,6 +221,13 @@ body {
 
 .site-footer {
 	background: #363636 url("/base/images/bg.png");
+}
+
+@media only screen and (max-width:768px) {
+  .site-footer .row{
+    margin-left:50px;
+  }
+
 }
 
 .resource-item {

--- a/ckanext/surrey/plugin.py
+++ b/ckanext/surrey/plugin.py
@@ -40,20 +40,16 @@ class SurreyFacetPlugin(plugins.SingletonPlugin):
         default_facet_titles = {
                     'groups': tk._('Categories'),
                     'tags': tk._('Tags'),
-                    'res_format': tk._('Formats')
+                    'res_format': tk._('Formats'),
                     #'license_id': tk._('License'),
                     }
         return default_facet_titles
 
     def group_facets(self, facets_dict, group_type, package_type):
 
-        default_facet_titles = {
-                    'groups': tk._('Categories'),
-                    'tags': tk._('Tags'),
-                    'res_format': tk._('Formats')
-                    #'license_id': tk._('License'),
-                    }
-        return default_facet_titles
+        facets_dict.pop('license_id')
+        facets_dict.pop('organization')
+        return facets_dict
 
 class SurreyExtraPagesPlugin(plugins.SingletonPlugin):
 

--- a/ckanext/surrey/templates/group/snippets/info.html
+++ b/ckanext/surrey/templates/group/snippets/info.html
@@ -20,7 +20,7 @@
         </dl>
         <dl>
           <dt>{{ _('Datasets') }}</dt>
-          <dd>{{ h.SI_number_span(group.packages|length) }}</dd>
+          <dd>{{ h.SI_number_span(group.package_count) }}</dd>
         </dl>
       </div>
       <div class="follow_button">

--- a/ckanext/surrey/templates/header.html
+++ b/ckanext/surrey/templates/header.html
@@ -8,5 +8,4 @@
     ('follow', _('Subscribe')),
     ('contact', _('Contact'))
   )}}
-  <li><a href="/pages/city-of-surrey-geospatial-data-disclaimer">Disclaimer</a></li>
 {% endblock %}


### PR DESCRIPTION
1. Add responsiveness for the head banner
2. group_facets() in surreyfacets plugin cannot work because of the upgrade. fixed it. See issue [#2731](https://github.com/ckan/ckan/issues/2713)
3. number of datasets in group page was always 0. The reason for this is CKAN2.4 does not display 'packages' by default when doing a 'package_show', so the original code that tries to get the length of packages attribute will always be 0. The fix is to just use package_count attribute.
4. Removed redundant 'disclaimer' page that I added in the last commit. It turned out their branch 'release-1.0' has already done this.
